### PR TITLE
Add ebextensions config file to run rake commands during deployment

### DIFF
--- a/01_seed_database.config
+++ b/01_seed_database.config
@@ -1,0 +1,4 @@
+# Run shell commands during a deployment
+container_commands:
+  01deploy:
+    command: rake reset:all

--- a/lib/tasks/reset.rake
+++ b/lib/tasks/reset.rake
@@ -1,0 +1,18 @@
+require 'csv'
+
+namespace :reset do
+  desc "Reset database and import meals"
+  task all: :environment do
+    MealFood.destroy_all
+    Food.destroy_all
+    Meal.destroy_all
+
+    ActiveRecord::Base.connection.reset_pk_sequence!(:table_name)
+
+
+    %w(Breakfast Lunch Snacks Dinner).each do | meal |
+      Meal.create(name: meal)
+      p "Created meal with a name of #{meal}"
+    end
+  end
+end


### PR DESCRIPTION
- Add rake reset:all to clear database and create four meals
- Add ebextensions config file to run above rake command on deployment